### PR TITLE
Fix patch paths and clarify Docker build platform args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@
 # Alpine version to build with
 ARG ALPINE_VERSION=3.19
 
-# Platform args, declared globally so they are usable in FROM expansions below.
-# BuildKit supplies these automatically; the defaults only matter if it does not.
-ARG TARGETARCH=amd64
-ARG TARGETPLATFORM
+# Platform args (TARGETARCH, TARGETPLATFORM) are referenced directly in FROM
+# expansions below without an ARG declaration here. BuildKit auto-populates these
+# for any FROM reference that doesn't shadow them; declaring them at global scope
+# (with or without a default) freezes them at that default instead, since an
+# explicit ARG overrides BuildKit's implicit value. Each stage that needs
+# $TARGETARCH in a RUN re-declares ARG TARGETARCH locally after its own FROM
+# (see the "binaries" stage), which is unaffected by this.
 
 # --- BUILD STAGE ---
 # Build base alpine-sdk image for later build stages

--- a/patches/dropbear/runcvm.patch
+++ b/patches/dropbear/runcvm.patch
@@ -1,5 +1,5 @@
---- a/src/cli-kex.c
-+++ b/src/cli-kex.c
+--- a/cli-kex.c
++++ b/cli-kex.c
 @@ -312,7 +312,7 @@
  	int ret;
  
@@ -9,8 +9,8 @@
  		return;
  	}
  
---- a/src/dbutil.c
-+++ b/src/dbutil.c
+--- a/dbutil.c
++++ b/dbutil.c
 @@ -140,7 +140,9 @@
  
  	vsnprintf(printbuf, sizeof(printbuf), format, param);
@@ -21,8 +21,8 @@
  
  }
  
---- a/src/default_options.h
-+++ b/src/default_options.h
+--- a/default_options.h
++++ b/default_options.h
 @@ -21,10 +21,10 @@
  /* Default hostkey paths - these can be specified on the command line.
   * Homedir is prepended if path begins with ~/


### PR DESCRIPTION
## Summary
This PR makes two key updates: it corrects file paths in the Dropbear patch file to remove the `src/` directory prefix, and it improves documentation around Docker build platform arguments to clarify how BuildKit's automatic platform detection works.

## Changes

### Dropbear Patch Updates
- Updated patch file paths from `src/cli-kex.c`, `src/dbutil.c`, and `src/default_options.h` to remove the `src/` prefix
- This aligns the patch with the actual file structure in the Dropbear source tree

### Docker Build Documentation
- Removed explicit global `ARG` declarations for `TARGETARCH` and `TARGETPLATFORM` that were freezing BuildKit's automatic values
- Added comprehensive comments explaining:
  - BuildKit automatically provides `TARGETARCH` and `TARGETPLATFORM` without explicit declaration
  - Declaring these args at global scope with defaults overrides BuildKit's implicit values
  - Individual build stages that need `$TARGETARCH` in `RUN` commands should declare it locally after their own `FROM` statement (as done in the "binaries" stage)
- This change allows BuildKit to properly auto-populate platform variables for multi-platform builds

## Implementation Details
The Docker changes follow BuildKit best practices for multi-platform builds: by removing the global ARG declarations, each `FROM` statement can now receive BuildKit's automatically-provided platform variables, while stages that need these values in `RUN` commands can declare them locally without interference.

https://claude.ai/code/session_01TGi7uPNuvtU3f9dM6sEkwS