### PR TITLE
Add dual-stack IPv6 networking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ RunCVM is free and open-source, licensed under the Apache Licence, Version 2.0. 
 - Command-line and image-embedded options for customising the a container's VM specifications, devices, kernel
 - Intelligent kernel selection, according to the distribution used in the image being launched
 - No external dependencies, except for Docker/Podman and relevant Linux kernel modules (`kvm` and `tun`)
-- Support multiple Docker network interfaces attached to a created (but not yet running) container using `docker run --network=<network>` and `docker network connect` (excluding IPv6)
+- Support multiple Docker network interfaces attached to a created (but not yet running) container using `docker run --network=<network>` and `docker network connect`
+- Dual-stack (IPv4 and IPv6) networking, where the host and Docker are already configured to support it
 
 ## Project ambitions
 
@@ -296,6 +297,8 @@ At time of writing:
 - the Google Cloud Debian image has default `1` and `rp_filter` settings in `/etc/sysctl.d/60-gce-network-security.conf` must be modified or overridden to support RunCVM.
 
 We recommend `all/rp_filter` be set to 2, as this is the simplest change and provides a good balance of security.
+
+This requirement is IPv4-specific: Linux has no IPv6 equivalent of `rp_filter`, so no further host configuration is needed to support the IPv4-proxied DNS/exec helper channel used by dual-stack Container/VMs.
 
 ## Installation
 
@@ -373,7 +376,9 @@ In the below summary of RunCVM's current main features and limitations, [+] is u
       - [+] `--hostname` (or `-h`) is supported
       - [-] `docker network connect` on a running container is not supported
       - [-] `--network=host` and `--network=container:name|id` are not supported
-      - [-] IPv6 is not supported
+      - [+] Dual-stack (IPv4 and IPv6) networking is supported, automatically, where the host and Docker are already configured for IPv6 (see `--env=RUNCVM_IPV6=<0|1>`)
+      - [-] IPv6-only networks (i.e. with no IPv4 connectivity at all) are not supported: a working IPv4 leg is required
+      - [-] `--dns=<IPv6 address>` is not supported: outgoing DNS requests are proxied via `dnsmasq` running in the container, which is only ever given an IPv4 address
    - Execution environment
       - [+] `--user` (or `-u`) is supported
       - [?] `--workdir` (or `-w`) is supported
@@ -594,6 +599,10 @@ By default SeaBIOS is used to boot the VM. Enable OVMF EFI boot with this option
 
 Enable use of [virtio vhost-net](https://www.redhat.com/en/blog/introduction-virtio-networking-and-vhost-net) (reliant on host `vhost_net` module and `/dev/vhost-net` device) to accelerate networking.
 
+### `--env=RUNCVM_IPV6=<0|1>`
+
+By default, IPv6 is enabled in the VM automatically if a global IPv6 address was assigned to the container (i.e. the Docker network is dual-stack), and disabled otherwise. Set to `1` to force IPv6 on regardless, or `0` to force it off (e.g. to keep a container IPv4-only despite being attached to a dual-stack network).
+
 ### `--env=RUNCVM_SYS_ADMIN=1`
 
 By default, `virtiofsd` is not launched with `-o modcaps=+sys_admin` (and containers are not granted `CAP_SYS_ADMIN`). Use this option if you need to change this.
@@ -731,7 +740,7 @@ In more detail, the RunCVM runtime `create` process:
 
 The `runcvm-ctr-entrypoint`:
 - Is always launched as PID1 within the standard Docker container.
-- Saves the container's originally-intended entrypoint and command line, environment variables and network configuration to files inside `/.runcvm`.
+- Saves the container's originally-intended entrypoint and command line, environment variables and network configuration (IPv4, and IPv6 if a global IPv6 address is present) to files inside `/.runcvm`.
 - Creates a bridge (acting as a hub) for each container network interface, to join that interface to a VM tap network interface.
 - Launches `virtiofsd` to serve the container's root filesystem.
 - Configures `/etc/resolv.conf` in the container.
@@ -745,12 +754,12 @@ The `runcvm-init` process:
 
 The `runcvm-ctr-qemu` script:
 - Prepares disk backing files as specified by `--env=RUNCVM_DISKS=<disks>`
-- Prepares network configuration as saved from the container (modifying the MAC address of each container interface)
+- Prepares network configuration as saved from the container (modifying the MAC address of each container interface), enabling IPv6 support in the VM's kernel command line if a global IPv6 address was saved for any interface (or if forced with `--env=RUNCVM_IPV6=1`)
 - Launches [QEMU](https://www.qemu.org/) with the required kernel, network interfaces, disks, display, and with a root filesystem mounted via virtiofs from the container and with `runcvm-vm-init` as the VM's init process.
 
 The `runcvm-vm-init` process:
 - Runs as PID1 within the VM.
-- Retrieves the container configuration - network, environment, disk and tmpfs mounts - saved by `runcvm-ctr-entrypoint` to `/.runcvm`, and reproduces it within the VM
+- Retrieves the container configuration - network (IPv4, and IPv6 if present), environment, disk and tmpfs mounts - saved by `runcvm-ctr-entrypoint` to `/.runcvm`, and reproduces it within the VM
 - Launches the container's pre-existing entrypoint, in one of two ways.
    1. If `RUNCVM_INIT` is `1` (i.e. the container was originally intended to be launched with Docker's own init process) then it configures and execs busybox `init`, which becomes the VM's PID1, to supervise `dropbear`, run `runcvm-vm-start` and `poweroff` the VM if signalled to do so.
    2. Else, it backgrounds `dropbear`, then execs (via `runcvm-init`, purely to create a controlling tty) `runcvm-vm-start`, which runs as the VM's PID1.

--- a/runcvm-scripts/runcvm-ctr-defaults
+++ b/runcvm-scripts/runcvm-ctr-defaults
@@ -43,6 +43,11 @@ load_network() {
 # i.e. /.runcvm/network/devices6 does not exist.
 load_network6() {
   local if="${1:-default}"
+  # Always reset first: unlike load_network(), this is routinely called for
+  # interfaces that turn out to have no IPv6, and callers rely on
+  # DOCKER_IF6_* being genuinely empty (not left over from a previous
+  # interface) when this returns 1.
+  DOCKER_IF6= DOCKER_IF6_IP= DOCKER_IF6_IP_NETPREFIX= DOCKER_IF6_IP_GW=
   [ -d /.runcvm/network/devices6 ] && [ -s /.runcvm/network/devices6/$if ] || return 1
   read -r DOCKER_IF6 DOCKER_IF6_IP DOCKER_IF6_IP_NETPREFIX DOCKER_IF6_IP_GW </.runcvm/network/devices6/$if
   return 0

--- a/runcvm-scripts/runcvm-ctr-defaults
+++ b/runcvm-scripts/runcvm-ctr-defaults
@@ -17,6 +17,7 @@ clean_env() {
   RUNCVM_BIOS_DEBUG RUNCVM_BIOS \
   RUNCVM_DISPLAY_MODE \
   RUNCVM_QEMU_DEBUG RUNCVM_QEMU_ARCH RUNCVM_QEMU_DISPLAY RUNCVM_QEMU_VGA RUNCVM_QEMU_VNC_DISPLAY RUNCVM_QEMU_USB RUNCVM_QEMU_NET_VHOST RUNCVM_QEMU_MEM_PREALLOC \
+  RUNCVM_IPV6 \
   RUNCVM_KERNEL RUNCVM_KERNEL_ROOT RUNCVM_KERNEL_APPEND RUNCVM_KERNEL_INITRAMFS_PATH RUNCVM_KERNEL_DEBUG RUNCVM_KERNEL_PATH \
   RUNCVM_DISKS \
   RUNCVM_UIDGID RUNCVM_VM_MOUNTPOINT RUNCVM_TMPFS \
@@ -33,6 +34,17 @@ load_network() {
   local if="${1:-default}"
   [ -d /.runcvm/network/devices ] && [ -s /.runcvm/network/devices/$if ] || return 1
   read -r DOCKER_IF DOCKER_IF_MAC DOCKER_IF_MTU DOCKER_IF_IP DOCKER_IF_IP_NETPREFIX DOCKER_IF_IP_GW </.runcvm/network/devices/$if
+  return 0
+}
+
+# Loads IPv6 addressing for interface $1 (or the default-route interface, if
+# omitted), if any was captured. Returns 1 (leaving DOCKER_IF6_* unset) for an
+# interface with no IPv6 address, or when the container has no IPv6 at all,
+# i.e. /.runcvm/network/devices6 does not exist.
+load_network6() {
+  local if="${1:-default}"
+  [ -d /.runcvm/network/devices6 ] && [ -s /.runcvm/network/devices6/$if ] || return 1
+  read -r DOCKER_IF6 DOCKER_IF6_IP DOCKER_IF6_IP_NETPREFIX DOCKER_IF6_IP_GW </.runcvm/network/devices6/$if
   return 0
 }
 

--- a/runcvm-scripts/runcvm-ctr-entrypoint
+++ b/runcvm-scripts/runcvm-ctr-entrypoint
@@ -86,6 +86,11 @@ read -r DOCKER_GW_IF DOCKER_GW_IF_IP < \
   <(ip -json route show | jq -r '.[] | (select(.dst == "default") | [.dev, .gateway]) | @tsv')
 # e.g. eth0 172.25.10.1
 
+# Identify IPv6 default gateway device and IP address, if any.
+read -r DOCKER_GW_IF6 DOCKER_GW_IF6_IP < \
+  <(ip -6 -json route show default | jq -r '.[0] | [.dev, .gateway] | @tsv')
+# e.g. eth0 fd00:1::1
+
 QEMU_BRIDGE_IP=169.254.1.1
 RUNCVM_DNS_IP=169.254.169.254
 
@@ -94,18 +99,31 @@ mkdir -p /.runcvm/network/devices
 # Save non-link-scope non-default routes for later restoration in the running VM.
 ip -json route show | jq -r '.[] | select(.scope != "link" and .dst != "default") | "\(.dst) \(.gateway) \(.dev) \(.prefsrc)"' >/.runcvm/network/routes
 
+# Save non-kernel (i.e. non-connected, non-link-local) non-default IPv6 routes
+# for later restoration in the running VM. Kernel-derived on-link prefix routes
+# are handled per-interface (as DOCKER_NET6, below); fe80::/64 is link-local and
+# is recreated automatically by the kernel when the VM brings up its interface.
+ip -6 -json route show | jq -r '.[] | select(.protocol != "kernel" and .dst != "default" and .dst != "fe80::/64") | "\(.dst) \(.gateway) \(.dev)"' >/.runcvm/network/routes6
+
 for if in $(ip -json link show | jq -r '.[] | .ifname')
 do
 
   [ "$if" = "lo" ] && continue
 
   read -r DOCKER_IF_IP DOCKER_IF_IP_NETPREFIX DOCKER_IF_MAC DOCKER_IF_MTU < \
-    <(ip -json addr show "$if" | jq -r '.[0] | [.addr_info[0].local, .addr_info[0].prefixlen, .address, .mtu] | @tsv')
+    <(ip -json addr show "$if" | jq -r '.[0] as $l | first($l.addr_info[] | select(.family=="inet")) as $a | [$a.local, $a.prefixlen, $l.address, $l.mtu] | @tsv')
   # e.g. 172.25.10.2 24 52:54:00:b7:0b:b6 1500
 
   # Capture the on-link (connected) route prefix for this interface, before its
   # address (and the kernel route derived from it) is flushed below.
   DOCKER_NET=$(ip -json route show dev "$if" scope link | jq -r '.[0].dst')
+
+  # Capture a global IPv6 address for this interface, if any. Absence of a
+  # devices6/<if> file for an interface is what signals "no IPv6 on this
+  # interface" downstream. Unlike IPv4, no container-side IPv6 address or
+  # route is restored below: the VM is the sole owner of this address.
+  read -r DOCKER_IF6_IP DOCKER_IF6_IP_NETPREFIX < \
+    <(ip -json addr show "$if" | jq -r '.[0].addr_info[] | select(.family=="inet6" and .scope=="global" and ((.deprecated // false) | not)) | [.local, .prefixlen] | @tsv' | head -n 1)
 
   # Save container network parameters
   if [ "$if" = "$DOCKER_GW_IF" ]; then
@@ -117,6 +135,20 @@ do
     printf "%s %s %s %s %s %s\n" \
       "$if" "$DOCKER_IF_MAC" "$DOCKER_IF_MTU" "$DOCKER_IF_IP" "$DOCKER_IF_IP_NETPREFIX" "-" \
       >/.runcvm/network/devices/$if
+  fi
+
+  if [ -n "$DOCKER_IF6_IP" ]; then
+    mkdir -p /.runcvm/network/devices6
+    if [ "$if" = "$DOCKER_GW_IF6" ]; then
+      printf "%s %s %s %s\n" \
+        "$if" "$DOCKER_IF6_IP" "$DOCKER_IF6_IP_NETPREFIX" "$DOCKER_GW_IF6_IP" \
+        >/.runcvm/network/devices6/$if
+      ln -s "$if" /.runcvm/network/devices6/default
+    else
+      printf "%s %s %s %s\n" \
+        "$if" "$DOCKER_IF6_IP" "$DOCKER_IF6_IP_NETPREFIX" "-" \
+        >/.runcvm/network/devices6/$if
+    fi
   fi
 
   # RECONFIGURE CONTAINER NETWORK

--- a/runcvm-scripts/runcvm-ctr-entrypoint
+++ b/runcvm-scripts/runcvm-ctr-entrypoint
@@ -122,8 +122,12 @@ do
   # devices6/<if> file for an interface is what signals "no IPv6 on this
   # interface" downstream. Unlike IPv4, no container-side IPv6 address or
   # route is restored below: the VM is the sole owner of this address.
+  # (Under `set -e`, this read legitimately fails, with nothing to abort
+  # for, whenever this interface has no global IPv6 address - the common
+  # case for an IPv4-only container - since the underlying jq select()
+  # then produces no output at all for read to consume.)
   read -r DOCKER_IF6_IP DOCKER_IF6_IP_NETPREFIX < \
-    <(ip -json addr show "$if" | jq -r '.[0].addr_info[] | select(.family=="inet6" and .scope=="global" and ((.deprecated // false) | not)) | [.local, .prefixlen] | @tsv' | head -n 1)
+    <(ip -json addr show "$if" | jq -r '.[0].addr_info[] | select(.family=="inet6" and .scope=="global" and ((.deprecated // false) | not)) | [.local, .prefixlen] | @tsv' | head -n 1) || true
 
   # Save container network parameters
   if [ "$if" = "$DOCKER_GW_IF" ]; then

--- a/runcvm-scripts/runcvm-ctr-entrypoint
+++ b/runcvm-scripts/runcvm-ctr-entrypoint
@@ -103,6 +103,10 @@ do
     <(ip -json addr show "$if" | jq -r '.[0] | [.addr_info[0].local, .addr_info[0].prefixlen, .address, .mtu] | @tsv')
   # e.g. 172.25.10.2 24 52:54:00:b7:0b:b6 1500
 
+  # Capture the on-link (connected) route prefix for this interface, before its
+  # address (and the kernel route derived from it) is flushed below.
+  DOCKER_NET=$(ip -json route show dev "$if" scope link | jq -r '.[0].dst')
+
   # Save container network parameters
   if [ "$if" = "$DOCKER_GW_IF" ]; then
     printf "%s %s %s %s %s %s\n" \
@@ -132,7 +136,6 @@ do
   ip link set dev "$QEMU_BRIDGE" up
 
   # Restore network route via this bridge
-  DOCKER_NET=$(ip_prefix_to_network "$DOCKER_IF_IP" "$DOCKER_IF_IP_NETPREFIX")/"$DOCKER_IF_IP_NETPREFIX"
   ip route add "$DOCKER_NET" dev "$QEMU_BRIDGE"
 
   # If this interface is the default gateway interface, perform additional special steps.

--- a/runcvm-scripts/runcvm-ctr-qemu
+++ b/runcvm-scripts/runcvm-ctr-qemu
@@ -125,6 +125,8 @@ do_networks() {
   local id=0 ifpath if mac vhost
   local DOCKER_IF DOCKER_IF_MAC DOCKER_IF_MTU DOCKER_IF_IP DOCKER_IF_IP_NETPREFIX DOCKER_IF_IP_GW
 
+  HAS_IPV6=0
+
   for ifpath in /.runcvm/network/devices/*
   do
     if=$(busybox basename "$ifpath")
@@ -132,6 +134,12 @@ do_networks() {
     [ "$if" = "default" ] && continue
 
     load_network "$if"
+
+    # Set (not local): read by the caller to decide whether to enable IPv6
+    # on the VM's kernel command line.
+    if load_network6 "$if"; then
+      HAS_IPV6=1
+    fi
 
     mac=$(busybox sed -r 's/^..:..:../52:54:00/' <<<$DOCKER_IF_MAC)
 
@@ -329,8 +337,17 @@ VIRTIOFS+=(
 # Experimental: Enable for a SCSI bus
 # OPTS+=(-device virtio-scsi-pci,id=scsi0,disable-modern=true)
 
-# Disable IPv6, which is currently unsupported, at kernel boot time
-APPEND+=(ipv6.disable=1 panic=-1)
+# Enable IPv6 in the VM only if a global IPv6 address was captured for at
+# least one interface (set by do_networks(), above), unless overridden with
+# --env=RUNCVM_IPV6=<0|1>. Otherwise, disable IPv6 entirely at kernel boot
+# time, as before.
+case "$RUNCVM_IPV6" in
+  1) HAS_IPV6=1 ;;
+  0) HAS_IPV6=0 ;;
+esac
+
+[ "$HAS_IPV6" = "1" ] || APPEND+=(ipv6.disable=1)
+APPEND+=(panic=-1)
 
 # Disable unneeded functionality
 APPEND+=(scsi_mod.scan=none tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests pci=lastbus=0 selinux=0)

--- a/runcvm-scripts/runcvm-ip-functions
+++ b/runcvm-scripts/runcvm-ip-functions
@@ -1,44 +1,5 @@
 #!/bin/bash
 
-cidr_to_int() {
-  echo "$(( 0xffffffff ^ ((1 << (32 - $1)) - 1) ))"
-}
-
-int_to_ip() {
-  local value="$1"
-  echo "$(( ($1 >> 24) & 0xff )).$(( ($1 >> 16) & 0xff )).$(( ($1 >> 8) & 0xff )).$(( $1 & 0xff ))"
-}
-
-cidr_to_netmask() {
-  local value=$(cidr_to_int "$1")
-  int_to_ip "$value"
-}
-
-ip_prefix_to_network() {
-  local IFS i1 i2 i3 i4 m1 m2 m3 m4
-  IFS=. read -r i1 i2 i3 i4 <<< "$1"
-
-  local mask=$(cidr_to_netmask "$2")
-  IFS=. read -r m1 m2 m3 m4 <<< "$mask"
-
-  printf "%d.%d.%d.%d\n" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))"
-}
-
-cidr_to_bcastmask() {
-  local value=$(( (1 << 32) - $(cidr_to_int "$1") - 1 ))
-  int_to_ip "$value"
-}
-
-ip_prefix_to_bcast() {
-  local IFS i1 i2 i3 i4 m1 m2 m3 m4
-  IFS=. read -r i1 i2 i3 i4 <<< "$1"
-
-  local mask=$(cidr_to_bcastmask "$2")
-  IFS=. read -r m1 m2 m3 m4 <<< "$mask"
-
-  printf "%d.%d.%d.%d\n" "$((i1 | m1))" "$((i2 | m2))" "$((i3 | m3))" "$((i4 | m4))"
-}
-
 is_natural_int() {
     case $1 in
         ''|*[!0-9]*) return 1 ;;  # not numeric

--- a/runcvm-scripts/runcvm-vm-init
+++ b/runcvm-scripts/runcvm-vm-init
@@ -86,7 +86,7 @@ do
   ip link set $DOCKER_IF up mtu "${DOCKER_IF_MTU:=1500}"
 
   # If this is the default gateway interface, establish the default gateway
-  [ -n "$DOCKER_IF_IP_GW" ] && ip route add default via $DOCKER_IF_IP_GW
+  [ -n "$DOCKER_IF_IP_GW" ] && [ "$DOCKER_IF_IP_GW" != "-" ] && ip route add default via $DOCKER_IF_IP_GW
 done
 
 # Read and install any supplementary routes.

--- a/runcvm-scripts/runcvm-vm-init
+++ b/runcvm-scripts/runcvm-vm-init
@@ -42,14 +42,16 @@ if ! [ -h /dev/fd ]; then
   ln -s /proc/self/fd /dev/fd
 fi
 
-# FIXME: This must be run early enough, otherwise other interfaces like docker0 might have started
-IF=$(ls /sys/class/net/ | grep -vE '^(lo|docker)' | head -n 1)
-
+# Disable IPv6 on every interface by default (both those that already exist,
+# and any that may appear later), before any of them are renamed or brought
+# up, so that none of them briefly performs SLAAC/DAD or joins a
+# solicited-node multicast group using its unwanted kernel-assigned EUI-64
+# address. Interfaces with a captured IPv6 address are selectively
+# re-enabled, by their real (post-rename) name, below.
 # https://bugzilla.redhat.com/show_bug.cgi?id=501934
-for i in all $IF
+for i in default $(ls /sys/class/net/ | grep -v '^lo$')
 do
-  # /sbin/sysctl -q -w -e net.ipv6.conf.$i.disable_ipv6=1 net.ipv6.conf.$i.autoconf=0 net.ipv6.conf.$i.accept_ra=0
-  sysctl -q -w -e net.ipv6.conf.$i.disable_ipv6=1 net.ipv6.conf.$i.autoconf=0 || true
+  sysctl -q -w -e net.ipv6.conf.$i.disable_ipv6=1 net.ipv6.conf.$i.autoconf=0 net.ipv6.conf.$i.accept_ra=0 || true
 done
 
 # Bring up local interface
@@ -82,11 +84,33 @@ do
   load_network "$if"
 
   ip link set $DOCKER_IF-tmp name $DOCKER_IF
+
+  if load_network6 "$if"; then
+    # Re-enable IPv6 on this interface only. accept_ra/autoconf are left off
+    # (as set for every interface above): Docker addresses IPv6 statically,
+    # like IPv4, and runs no RA daemon on its bridge networks, so the VM
+    # should behave deterministically rather than react to anything it can
+    # now see on the raw L2 segment.
+    sysctl -q -w -e net.ipv6.conf.$DOCKER_IF.disable_ipv6=0 net.ipv6.conf.$DOCKER_IF.autoconf=0 net.ipv6.conf.$DOCKER_IF.accept_ra=0 || true
+  fi
+
   ip addr add $DOCKER_IF_IP/$DOCKER_IF_IP_NETPREFIX broadcast + dev $DOCKER_IF
   ip link set $DOCKER_IF up mtu "${DOCKER_IF_MTU:=1500}"
 
   # If this is the default gateway interface, establish the default gateway
   [ -n "$DOCKER_IF_IP_GW" ] && [ "$DOCKER_IF_IP_GW" != "-" ] && ip route add default via $DOCKER_IF_IP_GW
+
+  if [ -n "$DOCKER_IF6_IP" ]; then
+    # The address is definitionally ours: Docker allocated it, and the
+    # container released it (at entrypoint time, before enslaving this
+    # interface) well before this point, so nothing else can answer for it.
+    # Skip DAD so the address is usable immediately: with DAD enabled the
+    # address is 'tentative' for ~1s, and the default route below would
+    # otherwise intermittently fail ('Network is unreachable') against a
+    # tentative source address.
+    ip -6 addr add $DOCKER_IF6_IP/$DOCKER_IF6_IP_NETPREFIX dev $DOCKER_IF nodad
+    [ -n "$DOCKER_IF6_IP_GW" ] && [ "$DOCKER_IF6_IP_GW" != "-" ] && ip -6 route add default via $DOCKER_IF6_IP_GW dev $DOCKER_IF
+  fi
 done
 
 # Read and install any supplementary routes.
@@ -95,6 +119,13 @@ do
   [ -n "$DOCKER_RT_NET" ] && [ -n "$DOCKER_RT_GW" ] && [ -n "$DOCKER_RT_DEV" ] && \
     ip route add "$DOCKER_RT_NET" via "$DOCKER_RT_GW" dev "$DOCKER_RT_DEV" || true
 done </.runcvm/network/routes
+
+# Read and install any supplementary IPv6 routes.
+while read -r DOCKER_RT6_NET DOCKER_RT6_GW DOCKER_RT6_DEV
+do
+  [ -n "$DOCKER_RT6_NET" ] && [ -n "$DOCKER_RT6_GW" ] && [ -n "$DOCKER_RT6_DEV" ] && \
+    ip -6 route add "$DOCKER_RT6_NET" via "$DOCKER_RT6_GW" dev "$DOCKER_RT6_DEV" || true
+done </.runcvm/network/routes6
 
 # TODO
 # - bind-mount or overwrite /etc/resolv.conf, /etc/hosts and /etc/hostname?

--- a/tests/04-ipv6/test
+++ b/tests/04-ipv6/test
@@ -1,0 +1,112 @@
+#!/bin/bash -e
+
+# Load framework functions
+. ../framework.sh
+
+# TEST VARIABLES
+NODE=runcvm-04-ipv6-test
+NETWORK="$NODE-network"
+NETWORK2="$NODE-network2"
+IMAGE="alpine"
+RUNTIME="${RUNTIME:-runcvm}"
+SUBNET6="fd00:$(printf '%04x' $RANDOM):$(printf '%04x' $RANDOM)::/64"
+
+# OVERRIDE FRAMEWORK FUNCTIONS
+nodes() { echo "$NODE-a" "$NODE-b" "$NODE-multi"; }
+networks() { echo "$NETWORK" "$NETWORK2"; }
+
+# TEST FUNCTIONS
+# --------------
+
+ERRORS=0
+
+test_result() {
+  local desc="$1" rc="$2"
+  if [ "$rc" = "0" ]; then
+    log "$desc - PASS"
+  else
+    log "$desc - FAIL"
+    ERRORS=$((ERRORS+1))
+  fi
+}
+
+# TEST PROCEDURE
+# --------------
+
+# Run routine cleanup of any preexisting containers, volumes, networks, and images
+cleanup
+
+# Create a dual-stack network. If dockerd doesn't support --ipv6 (e.g. IPv6
+# is not enabled in daemon.json), skip this test cleanly rather than fail
+# it: dual-stack RunCVM support requires the host and dockerd to already be
+# IPv6-configured, which this test cannot itself provide.
+log -n "Creating dual-stack network '$NETWORK' (subnet $SUBNET6) ..."
+if ! docker network create --ipv6 --subnet="$SUBNET6" "$NETWORK" >/tmp/04-ipv6-network-create.log 2>&1; then
+  log "SKIPPED: could not create an IPv6-enabled Docker network - is dockerd running with --ipv6 (or an equivalent daemon.json 'ipv6: true' / 'default-address-pools' with an IPv6 pool)?"
+  cat /tmp/04-ipv6-network-create.log
+  rm -f /tmp/04-ipv6-network-create.log
+  exit 0
+fi
+rm -f /tmp/04-ipv6-network-create.log
+
+log -n "Creating plain (IPv4-only) network '$NETWORK2' ..."
+docker network create "$NETWORK2"
+
+# Launch two RunCVM containers on the dual-stack network.
+for n in a b; do
+  log -n "Launching RunCVM container '$NODE-$n' ..."
+  docker run -d --rm --runtime=$RUNTIME --network=$NETWORK --name=$NODE-$n --hostname=$NODE-$n $IMAGE \
+    sh -c 'while true; do sleep 1; done'
+done
+
+# Regression test for the runcvm-vm-init default-gateway sentinel bug
+# (fixed alongside this test): a container attached to a second network at
+# create time - the only way RunCVM supports multiple interfaces - must
+# still boot. Before the fix, the VM's PID1 died during boot for any
+# non-default-gateway interface.
+log -n "Creating multi-interface container '$NODE-multi' (regression test) ..."
+docker create --runtime=$RUNTIME --name=$NODE-multi --hostname=$NODE-multi --network=$NETWORK $IMAGE \
+  sh -c 'while true; do sleep 1; done' >/dev/null
+docker network connect "$NETWORK2" $NODE-multi
+docker start $NODE-multi >/dev/null
+
+# Give the VMs time to finish booting (dropbear must be up for 'docker exec').
+log "Waiting for VMs to finish booting ..."
+sleep 8
+
+test_result "Multi-interface container boots and accepts 'docker exec'" \
+  "$(docker exec $NODE-multi true >/dev/null 2>&1; echo $?)"
+
+# Confirm the VM picked up the IPv4 address Docker assigned to the container
+# (regression check: dual-stack support must not disturb existing IPv4).
+EXPECTED_IP4=$(docker inspect $NODE-a --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+VM_IP4=$(docker exec $NODE-a sh -c "ip -o -4 addr show eth0 | awk '{print \$4}' | cut -d/ -f1" 2>/dev/null || true)
+test_result "VM has Docker-assigned IPv4 address (expected '$EXPECTED_IP4', got '$VM_IP4')" \
+  "$([ -n "$EXPECTED_IP4" ] && [ "$VM_IP4" = "$EXPECTED_IP4" ] && echo 0 || echo 1)"
+
+# Confirm the VM picked up the IPv6 address Docker assigned to the container.
+EXPECTED_IP6=$(docker inspect $NODE-a --format='{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}')
+VM_IP6=$(docker exec $NODE-a sh -c "ip -o -6 addr show eth0 scope global | awk '{print \$4}' | cut -d/ -f1" 2>/dev/null || true)
+test_result "VM has Docker-assigned IPv6 address (expected '$EXPECTED_IP6', got '$VM_IP6')" \
+  "$([ -n "$EXPECTED_IP6" ] && [ "$VM_IP6" = "$EXPECTED_IP6" ] && echo 0 || echo 1)"
+
+# Confirm the VM's IPv6 default route matches the network's gateway.
+GATEWAYS=$(docker network inspect "$NETWORK" --format='{{range .IPAM.Config}}{{.Gateway}}{{"\n"}}{{end}}')
+EXPECTED_GW6=$(echo "$GATEWAYS" | grep ':' || true)
+VM_GW6=$(docker exec $NODE-a sh -c "ip -6 route show default | awk '{print \$3}'" 2>/dev/null || true)
+test_result "VM has IPv6 default route via network gateway (expected '$EXPECTED_GW6', got '$VM_GW6')" \
+  "$([ -n "$EXPECTED_GW6" ] && [ "$VM_GW6" = "$EXPECTED_GW6" ] && echo 0 || echo 1)"
+
+# The money test: node A reaches node B by container name over IPv6. This
+# exercises Docker DNS returning an AAAA record (resolved via the existing
+# IPv4-only helper channel: dnsmasq in the container, reached over the
+# container's own loopback/bridge - unaffected by this change) *and* the
+# IPv6 datapath across the container<->VM hub bridge on both ends.
+docker exec -d $NODE-b sh -c "nc -6 -l -p 12345 >/tmp/nc-listen.out 2>&1"
+sleep 1
+test_result "IPv6 connectivity from '$NODE-a' to '$NODE-b' by container name" \
+  "$(docker exec $NODE-a sh -c "echo hello | nc -6 -w 3 $NODE-b 12345" >/dev/null 2>&1; echo $?)"
+
+# Final output
+log "Tests completed with $ERRORS errors"
+exit $ERRORS


### PR DESCRIPTION
## Summary

This PR adds comprehensive IPv6 support to RunCVM, enabling containers to use dual-stack (IPv4 and IPv6) Docker networks. IPv6 is automatically enabled when a global IPv6 address is assigned to the container, and can be manually controlled via the `RUNCVM_IPV6` environment variable.

## Key Changes

- **IPv6 address capture and configuration**: Modified `runcvm-ctr-entrypoint` to capture global IPv6 addresses from container interfaces and store them separately in `/.runcvm/network/devices6/` for use by the VM
- **VM-side IPv6 initialization**: Updated `runcvm-vm-init` to:
  - Disable IPv6 globally at boot to prevent unwanted SLAAC/DAD on all interfaces
  - Selectively re-enable IPv6 only on interfaces with captured addresses
  - Configure IPv6 addresses with DAD disabled for immediate usability
  - Add IPv6 default routes and supplementary routes from `/.runcvm/network/routes6`
- **IPv6 route handling**: Added support for capturing and restoring non-kernel IPv6 routes (excluding kernel-derived connected routes and link-local addresses)
- **Kernel command line control**: Modified `runcvm-ctr-qemu` to conditionally disable IPv6 at kernel boot time based on whether any interface has a global IPv6 address, with override capability via `RUNCVM_IPV6` environment variable
- **Helper function library**: Removed unused IPv4-specific CIDR/netmask calculation functions from `runcvm-ip-functions` (now handled by `jq` in the entrypoint)
- **New helper function**: Added `load_network6()` to `runcvm-ctr-defaults` for loading IPv6 configuration per-interface
- **Comprehensive test suite**: Added `tests/04-ipv6/test` covering:
  - Multi-interface container boot (regression test for default-gateway sentinel bug)
  - IPv4 address assignment verification
  - IPv6 address assignment verification
  - IPv6 default route configuration
  - IPv6 connectivity between containers by DNS name
- **Documentation updates**: Updated README to reflect IPv6 support status and limitations

## Notable Implementation Details

- IPv6 is disabled globally at VM boot time, then selectively re-enabled per-interface to prevent unwanted multicast group joins and address autoconfiguration
- DAD (Duplicate Address Detection) is skipped for Docker-assigned IPv6 addresses since they are guaranteed unique and need immediate usability
- The existing IPv4-only DNS/exec helper channel (dnsmasq in container over IPv4 loopback) is reused for IPv6 containers, avoiding the need for IPv6-specific DNS infrastructure
- IPv6-only networks are not supported; a working IPv4 leg is required for the helper channel
- The test gracefully skips if the Docker daemon doesn't have IPv6 enabled, rather than failing

https://claude.ai/code/session_01SkBvaHzPUEuAbddFVfErPQ